### PR TITLE
fix: upgrade GenAI model to gemini-2.5-flash

### DIFF
--- a/mod.phase3.out/service/src/main/java/com/shoppingcart/AiProductInfoService.java
+++ b/mod.phase3.out/service/src/main/java/com/shoppingcart/AiProductInfoService.java
@@ -27,7 +27,7 @@ public class AiProductInfoService {
 
         try {
             String prompt = "Provide a short, engaging product description for the product named: " + productName;
-            GenerateContentResponse response = client.models.generateContent("gemini-1.5-flash", prompt, null);
+            GenerateContentResponse response = client.models.generateContent("gemini-2.5-flash", prompt, null);
             return new AiProductInfoDTO(response.text());
         } catch (Exception e) {
             LOGGER.error("Error calling Gemini API for productName: {}", productName, e);

--- a/mod.phase3.out/service/src/main/java/com/shoppingcart/controller/ChatbotController.java
+++ b/mod.phase3.out/service/src/main/java/com/shoppingcart/controller/ChatbotController.java
@@ -55,7 +55,7 @@ public class ChatbotController {
                                   "Example: {\"intent\": \"product_inquiry\", \"product_query\": \"Laptop Pro\"}\n" +
                                   "Message: " + userMessage;
 
-            intentResponseJson = genAiClient.models.generateContent("gemini-1.5-flash", intentPrompt, null).text();
+            intentResponseJson = genAiClient.models.generateContent("gemini-2.5-flash", intentPrompt, null).text();
             
             // Clean up the JSON string: replace single quotes with double quotes for robust parsing
             intentResponseJson = intentResponseJson.replace('"', '"');
@@ -95,11 +95,11 @@ public class ChatbotController {
                                              "Here is the product information: \"" + productInfo + "\". " +
                                              "Generate a helpful and concise response based on this information. " +
                                              "If the product was not found, inform the user politely.";
-                String aiResponse = genAiClient.models.generateContent("gemini-1.5-flash", finalResponsePrompt, null).text();
+                String aiResponse = genAiClient.models.generateContent("gemini-2.5-flash", finalResponsePrompt, null).text();
                 response.put("response", aiResponse);
             } else {
                 // Step 4: General question, use GenAI directly
-                String aiResponse = genAiClient.models.generateContent("gemini-1.5-flash", userMessage, null).text();
+                String aiResponse = genAiClient.models.generateContent("gemini-2.5-flash", userMessage, null).text();
                 response.put("response", aiResponse);
             }
 


### PR DESCRIPTION
Updated ChatbotController and AiProductInfoService to use `gemini-2.5-flash` instead of `gemini-1.5-flash` to resolve 404 errors, as the 1.5-flash model is retired for the v1beta API endpoint.